### PR TITLE
Auto-merge weekly papers README refresh PRs

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -45,7 +45,13 @@ jobs:
       #     YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
       #   run: python3 scripts/update_videos.py || true
 
+      # Keep creating a PR (do not push straight to main). Auto-merge happens
+      # in the next step. A separate pull_request workflow would not run:
+      # PRs opened with GITHUB_TOKEN do not trigger other workflows, and this
+      # repo has Allow auto-merge disabled so `gh pr merge --auto` cannot be
+      # used without extra secrets/settings.
       - name: Open pull request
+        id: cpr
         uses: peter-evans/create-pull-request@v6
         with:
           commit-message: "Refresh README with new papers"
@@ -55,6 +61,48 @@ jobs:
             - New peer-reviewed papers added to Papers
             - New arXiv preprints added to Recent arXiv Preprints (capped, oldest dropped)
 
-            Please review before merging — this PR is not auto-merged.
+            This weekly papers refresh is auto-merged when the PR is opened by
+            github-actions[bot] on branch automation/readme-refresh.
           branch: automation/readme-refresh
           delete-branch: true
+
+      # Only this papers refresh is eligible. Do not reuse this step if
+      # software/books/videos updates are re-enabled under a different PR.
+      - name: Auto-merge weekly papers refresh
+        if: github.repository == 'richardcsuwandi/awesome-bo' && steps.cpr.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
+          HEAD_SHA: ${{ steps.cpr.outputs.pull-request-head-sha }}
+        run: |
+          set -euo pipefail
+
+          title="$(gh pr view "$PR_NUMBER" --json title --jq .title)"
+          author="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .user.login)"
+          head="$(gh pr view "$PR_NUMBER" --json headRefName --jq .headRefName)"
+
+          if [ "$title" != "Weekly README refresh: papers" ] ||
+             [ "$author" != "github-actions[bot]" ] ||
+             [ "$head" != "automation/readme-refresh" ]; then
+            echo "Skipping auto-merge; PR does not match weekly papers refresh."
+            echo "title=$title author=$author head=$head"
+            exit 0
+          fi
+
+          merge_args=(--merge --delete-branch)
+          if [ -n "${HEAD_SHA}" ]; then
+            merge_args+=(--match-head-commit "$HEAD_SHA")
+          fi
+
+          # The PR can take a few seconds to become mergeable after creation.
+          for attempt in 1 2 3 4 5 6; do
+            if gh pr merge "$PR_NUMBER" "${merge_args[@]}"; then
+              echo "Merged #$PR_NUMBER"
+              exit 0
+            fi
+            echo "Merge attempt $attempt failed; waiting..."
+            sleep 10
+          done
+
+          echo "Failed to merge #$PR_NUMBER after retries"
+          exit 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Weekly paper-refresh PRs from `.github/workflows/update-readme.yml` now merge themselves after `peter-evans/create-pull-request`. Human PRs and other bot PRs are not auto-merged.

The refresh still opens a PR (it does not push straight to `main`). Auto-merge is limited to PRs that match all of:
- title `Weekly README refresh: papers`
- author `github-actions[bot]`
- head branch `automation/readme-refresh`
- this repository (`richardcsuwandi/awesome-bo`)

Software/books/videos updates stay commented out and are not part of this auto-merge.

## Why this approach
A separate `pull_request` workflow does **not** work here with `GITHUB_TOKEN`: PRs created by that token do not trigger other workflows.

GitHub’s “Allow auto-merge” setting is currently **off** on this repo, so `gh pr merge --auto` would fail. This change merges immediately in the same job with `gh pr merge --merge` (matching previous merge-commit history), using only `GITHUB_TOKEN`. No PAT or extra secrets.

## Open PR #4
[#4](https://github.com/richardcsuwandi/awesome-bo/pull/4) was opened by the old workflow and will **not** merge itself until this change is on `main`. After merge, either:
- wait for next Monday’s scheduled run, or
- run **Actions → Refresh README → Run workflow**

That run will update or reuse `#4` and then auto-merge it if it still matches the guards. Alternatively, merge `#4` manually.

## Test plan
- [x] Confirm existing workflow still creates PRs via `peter-evans/create-pull-request@v6` on `automation/readme-refresh`
- [x] Dry-run guards against `#4` (match / would merge) and human PR `#1` (skip)
- [x] Confirm repo `allow_auto_merge` is false and there are no other workflows/checks
- [ ] After this lands on `main`, Monday (or `workflow_dispatch`) should create the papers PR and merge it unattended

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69886351-ac12-4ead-9a7b-8254aa08668b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69886351-ac12-4ead-9a7b-8254aa08668b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

