### PR TITLE
Add BayBE to software lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Actively maintained libraries. Archived and maintenance-only packages are listed
 - [BoTorch](https://botorch.org/) - Modular Monte Carlo BO library built on PyTorch and GPyTorch.
 - [Trieste](https://github.com/secondmind-labs/trieste) - TensorFlow/GPflow toolbox for batch, constrained, multi-fidelity, and multi-objective BO.
 - [BoFire](https://github.com/experimental-design/bofire) - Experimental design and BO for mixed spaces, used in chemical and pharmaceutical settings.
+- [BayBE](https://github.com/emdgroup/baybe) - Bayesian DoE with chemical encodings and transfer learning.
 - [HEBO](https://github.com/huawei-noah/HEBO) - Heteroscedastic evolutionary BO from Huawei Noah's Ark Lab.
 - [SMAC3](https://github.com/automl/SMAC3) - Sequential model-based algorithm configuration, using random forests or GPs.
 - [OpenBox](https://github.com/PKU-DAIR/open-box) - Black-box optimization system with transfer, multi-fidelity, and distributed runs.

--- a/docs/software.md
+++ b/docs/software.md
@@ -11,6 +11,7 @@ The table covers every actively maintained library listed here, not a shortlist.
 | [BoTorch](https://botorch.org/) | PyTorch / GPyTorch | Yes | Yes | Yes | Research toolkit. You write the loop. |
 | [Trieste](https://github.com/secondmind-labs/trieste) | TensorFlow / GPflow | Yes | Yes | Yes | Modular ask-tell API. |
 | [BoFire](https://github.com/experimental-design/bofire) | BoTorch | Yes | Yes | Yes | Industrial DOE and chemistry. |
+| [BayBE](https://github.com/emdgroup/baybe) | BoTorch / GPyTorch | Yes | Yes | Yes | Bayesian DoE with chemical encodings and transfer learning. |
 | [HEBO](https://github.com/huawei-noah/HEBO) | GPyTorch / others | Yes | Yes | Yes | Strong AutoML competition record. |
 | [SMAC3](https://github.com/automl/SMAC3) | RF / GP | Yes | Limited | Yes | Algorithm configuration and HPO. |
 | [OpenBox](https://github.com/PKU-DAIR/open-box) | GP / TPE / RF | Yes | Yes | Yes | General black-box system. |
@@ -30,6 +31,7 @@ The table covers every actively maintained library listed here, not a shortlist.
 - [BoTorch](https://botorch.org/) - Modular Monte Carlo BO library built on PyTorch and GPyTorch.
 - [Trieste](https://github.com/secondmind-labs/trieste) - TensorFlow/GPflow toolbox for batch, constrained, multi-fidelity, and multi-objective BO.
 - [BoFire](https://github.com/experimental-design/bofire) - Experimental design and BO for mixed spaces, used in chemical and pharmaceutical settings.
+- [BayBE](https://github.com/emdgroup/baybe) - Bayesian DoE with chemical encodings and transfer learning.
 - [HEBO](https://github.com/huawei-noah/HEBO) - Heteroscedastic evolutionary BO from Huawei Noah's Ark Lab.
 - [SMAC3](https://github.com/automl/SMAC3) - Sequential model-based algorithm configuration, using random forests or GPs.
 - [OpenBox](https://github.com/PKU-DAIR/open-box) - Black-box optimization system with transfer, multi-fidelity, and distributed runs.


### PR DESCRIPTION
## What are you adding?

- [ ] Paper (method, survey, tutorial, or benchmark)
- [X] Software
- [ ] Other resource (book, video, blog, course)

## Checklist

- [X] I read [contributing.md](contributing.md)
- [X] The entry is in the right section
- [X] Paper entries are inserted by year (newest first), not appended. Foundations is oldest first. Surveys starts with Shahriari then Brochu.
- [X] Format is `- [Name](url) - Description.`
- [X] Description starts with an uppercase letter and ends with a period
- [X] This is not an application paper that only *uses* Bayesian optimization
- [X] The URL is not already in the README
- [X] I ran `python scripts/sync_docs.py`
